### PR TITLE
add tag filter for release build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,9 @@ workflows:
       - build-ubuntu:
           filters: &filters-build
             branches:
-              only:
-                - /release.*/
+              only: /release.*/
+            tags:
+              only: /^v[0-9]+(\.[0-9]+).*/
           requires:
             - lint-and-test
       - build-windows:

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ out/
 # Electron-builder
 dist
 release
+
+# Storybook build
+storybook-static


### PR DESCRIPTION
- Circle CI will build our electron application according to the following rule:  
  Filter branch with regex `/release.*/`  
  Filter tag with regex `/^v[0-9]+(\.[0-9]+).*/`
- Add storybook build directory to `.gitignore`