### PR TITLE
Add caching for wallet screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "react-popper": "2.2.5",
     "react-popper-tooltip": "4.3.0",
     "react-qr-reader": "2.2.1",
+    "react-query": "^3.19.6",
     "react-range": "1.8.8",
     "react-ratings-declarative": "3.4.1",
     "react-redux": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-popper": "2.2.5",
     "react-popper-tooltip": "4.3.0",
     "react-qr-reader": "2.2.1",
-    "react-query": "^3.19.6",
+    "react-query": "3.19.6",
     "react-range": "1.8.8",
     "react-ratings-declarative": "3.4.1",
     "react-redux": "7.2.3",

--- a/src/common/utils/queryClient.ts
+++ b/src/common/utils/queryClient.ts
@@ -1,0 +1,9 @@
+import { QueryClient } from 'react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      cacheTime: Infinity,
+    },
+  },
+})

--- a/src/features/app/__test__/mainSetup.test.ts
+++ b/src/features/app/__test__/mainSetup.test.ts
@@ -53,7 +53,7 @@ describe('mainSetup', () => {
 
     expect(createWindow).toHaveBeenCalled()
 
-    expect(mainEventPromise).toBeCalledWith('rendererStarted')
+    emitMainEvent('rendererStarted', null)
 
     expect(sendEventToRenderer).toHaveBeenCalledWith(
       'setAppInfo',
@@ -62,6 +62,7 @@ describe('mainSetup', () => {
     asMock(sendEventToRenderer).mockClear()
     expect(initServeStatic).toHaveBeenCalled()
     expect(startWalletNode).toHaveBeenCalled()
+    await nextTickPromise()
 
     expect(readRpcConfig).toHaveBeenCalled()
     resolveRpcConfig?.(rpcConfig)

--- a/src/features/app/__test__/rendererSetup.test.ts
+++ b/src/features/app/__test__/rendererSetup.test.ts
@@ -112,7 +112,7 @@ describe('rendererSetup', () => {
       expect(mockedStore.getActions()).toEqual([setPastelInfo({ info })])
     })
 
-    it('should setup pastel db thread if app is not packaged', async () => {
+    it('should setup pastel db thread', async () => {
       mockedStore.getState().appInfo = {
         isPackaged: false,
       }
@@ -124,16 +124,6 @@ describe('rendererSetup', () => {
         PastelDBThread,
         expect.any(Number),
       )
-
-      jest.clearAllMocks()
-      mockedStore.getState().appInfo = {
-        isPackaged: true,
-      }
-
-      await emitRendererEvent('setRpcConfig', { rpcConfig })
-
-      expect(PastelDBThread).not.toHaveBeenCalled()
-      expect(setInterval).not.toHaveBeenCalled()
     })
 
     it('should redirect to welcome page', async () => {

--- a/src/features/pastelDB/__tests__/pastelDBThread.test.ts
+++ b/src/features/pastelDB/__tests__/pastelDBThread.test.ts
@@ -552,7 +552,7 @@ describe('PastelDBThread', () => {
     })
   })
 
-  test('fetchTotalbalance works', async () => {
+  test('fetchTotalBalance works', async () => {
     // Arrange
     const rpcSpy = jest
       .spyOn(pastelRPC, 'rpc')
@@ -562,7 +562,7 @@ describe('PastelDBThread', () => {
       .mockImplementation()
 
     // Act
-    await pastelDBThread.fetchTotalbalance({
+    await pastelDBThread.fetchTotalBalance({
       pastelDB: pastelDB.db,
     })
 
@@ -743,7 +743,7 @@ describe('PastelDBThread', () => {
       .spyOn(pastelDBThread, 'fetchListunspent')
       .mockResolvedValue()
     const fetchTotalbalanceSpy = jest
-      .spyOn(pastelDBThread, 'fetchTotalbalance')
+      .spyOn(pastelDBThread, 'fetchTotalBalance')
       .mockResolvedValue()
     const fetchListaddressesSpy = jest
       .spyOn(pastelDBThread, 'fetchListaddresses')

--- a/src/features/wallet/BalanceCards.tsx
+++ b/src/features/wallet/BalanceCards.tsx
@@ -1,0 +1,153 @@
+import React, { ReactNode, useMemo } from 'react'
+import {
+  EliminationIcon,
+  ShieldedBalance,
+  TotalBalance,
+  TransparencyBalance,
+} from '../../common/components/Icons'
+import { TTotalBalance } from '../../types/rpc'
+import Tooltip from '../../common/components/Tooltip'
+import cn from 'classnames'
+import { useCurrencyName } from '../../common/hooks/appInfo'
+import { formatPrice } from '../../common/utils/format'
+import Spinner from '../../common/components/Spinner'
+
+type TBalanceCard = {
+  style: {
+    type: string
+    info: boolean
+  }
+  psl?: number
+  activeIcon: ReactNode
+  inactiveIcon: ReactNode
+  info: string
+}
+
+export default function BalanceCards({
+  totalBalances,
+  activeTab,
+  setActiveTab,
+}: {
+  totalBalances?: TTotalBalance
+  activeTab: number
+  setActiveTab(tab: number): void
+}): JSX.Element {
+  const currencyName = useCurrencyName()
+
+  const balanceCards = useMemo<TBalanceCard[]>(
+    () => [
+      {
+        style: {
+          type: 'total_balance',
+          info: false,
+        },
+        psl: totalBalances?.total,
+        activeIcon: <TotalBalance />,
+        inactiveIcon: <TotalBalance variant='inactive' />,
+        info: 'Total Balance',
+      },
+      {
+        style: {
+          type: 'transparent',
+          info: false,
+        },
+        psl: totalBalances?.transparent,
+        activeIcon: <TransparencyBalance />,
+        inactiveIcon: <TransparencyBalance variant='inactive' />,
+        info: 'Transparent Information',
+      },
+      {
+        style: {
+          type: 'shielded',
+          info: false,
+        },
+        psl: totalBalances?.private,
+        activeIcon: <ShieldedBalance />,
+        inactiveIcon: <ShieldedBalance variant='inactive' />,
+        info: 'Shielded Information',
+      },
+    ],
+    [totalBalances],
+  )
+
+  return (
+    <div className='flex justify-between'>
+      {balanceCards.map((card, index) => {
+        const isActive = activeTab === index
+
+        return (
+          <div
+            key={index}
+            onClick={() => setActiveTab(index)}
+            className='relative cursor-pointer'
+          >
+            <div className='absolute top-15px right-15px'>
+              {card.style.info ? (
+                <Tooltip
+                  classnames='pt-5px pl-9px pr-2.5 pb-1 text-xs'
+                  content={card.info}
+                  width={108}
+                  type='top'
+                >
+                  <EliminationIcon size={20} className='text-gray-8e' />
+                </Tooltip>
+              ) : null}
+            </div>
+            <div
+              className={cn(
+                'font-extrabold flex sm:w-64 md:w-72 lg:w-335px xl:w-427px h-124px border-gray-e7 border rounded-lg',
+                isActive && 'bg-white',
+              )}
+            >
+              <div className='pl-4 md:pl-4 lg:pl-4 xl:pl-39px flex items-center'>
+                {isActive ? card.activeIcon : card.inactiveIcon}
+              </div>
+              <div className='pt-36px pl-2 md:pl-3 lg:pl-[43px]'>
+                <div
+                  className={cn(
+                    'sm:text-xl md:text-2xl leading-6 pt-9',
+                    index === activeTab ? 'text-gray-2d' : 'text-gray-71',
+                  )}
+                >
+                  {card.psl === undefined ? (
+                    <Spinner className='w-6 h-6 mb-3' />
+                  ) : (
+                    formatPrice(card.psl, currencyName)
+                  )}
+                </div>
+                {card.style.type === 'total_balance' ? (
+                  <div
+                    className={cn(
+                      'font-medium text-sm mt-2',
+                      isActive ? 'text-gray-71' : 'text-gray-a0',
+                    )}
+                  >
+                    Total balance
+                  </div>
+                ) : card.style.type === 'transparent' ? (
+                  <div
+                    className={cn(
+                      'font-medium text-sm mt-2',
+                      isActive ? 'text-gray-71' : 'text-gray-a0',
+                    )}
+                  >
+                    Transparent
+                  </div>
+                ) : (
+                  <div
+                    className={cn(
+                      'font-medium text-sm mt-2',
+                      isActive ? 'text-gray-71' : 'text-gray-a0',
+                    )}
+                  >
+                    Shielded
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/wallet/WalletScreen.tsx
+++ b/src/features/wallet/WalletScreen.tsx
@@ -1,8 +1,5 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import NumberFormat from 'react-number-format'
-import cn from 'classnames'
-
-import Tooltip from 'common/components/Tooltip'
 import Toggle from 'common/components/Toggle'
 import Select from 'common/components/Select/Select'
 import { Button } from 'common/components/Buttons'
@@ -13,12 +10,7 @@ import TransactionHistoryModal from './TransactionHistoryModal'
 import ExportKeysModal from './ExportKeysModal'
 import Breadcrumbs from 'common/components/Breadcrumbs'
 import { WalletRPC } from 'api/pastel-rpc'
-import {
-  TAddressRow,
-  TBalanceCard,
-  TTotalBalance,
-  TAddressBalance,
-} from 'types/rpc'
+import { TAddressRow } from 'types/rpc'
 import QRCode from 'qrcode.react'
 import { useAppSelector } from 'redux/hooks'
 import { RootState } from '../../redux/store'
@@ -29,16 +21,14 @@ import 'react-toastify/dist/ReactToastify.css'
 import { ToastContainer } from 'react-toastify'
 import { isSapling } from 'api/helpers'
 import { useAddressBook } from 'common/hooks'
-
+import BalanceCards from './BalanceCards'
 import {
-  ShieldedBalance,
-  TotalBalance,
-  TransparencyBalance,
   ElectricityIcon,
   Clock,
   EliminationIcon,
   FilePDFIcon,
 } from 'common/components/Icons'
+import Spinner from '../../common/components/Spinner'
 
 const paymentSources = [
   {
@@ -152,38 +142,6 @@ const WalletScreen = (): JSX.Element => {
       ),
     },
   ]
-  const cardItems = [
-    {
-      style: {
-        type: 'total_balance',
-        info: false,
-      },
-      psl: 0,
-      activeIcon: <TotalBalance />,
-      inactiveIcon: <TotalBalance variant='inactive' />,
-      info: 'Total Balance',
-    },
-    {
-      style: {
-        type: 'transparent',
-        info: true,
-      },
-      psl: 0,
-      activeIcon: <TransparencyBalance />,
-      inactiveIcon: <TransparencyBalance variant='inactive' />,
-      info: 'Transparent Information',
-    },
-    {
-      style: {
-        type: 'shielded',
-        info: true,
-      },
-      psl: 0,
-      activeIcon: <ShieldedBalance />,
-      inactiveIcon: <ShieldedBalance variant='inactive' />,
-      info: 'Shielded Information',
-    },
-  ]
 
   const { lastFetched } = useAppSelector<RootState['pastelPrice']>(
     ({ pastelPrice }) => pastelPrice,
@@ -205,108 +163,73 @@ const WalletScreen = (): JSX.Element => {
 
   const [selectedAmount, setSelectedAmount] = useState(0)
   const [selectedRows, setSelectedRows] = useState<Array<string>>([])
-  const [balanceCards, setBalanceCards] = useState<TBalanceCard[]>(cardItems)
-  const [totalBalances, setTotalBalances] = useState<TTotalBalance>()
-  const [walletAddresses, setWalletAddresses] = useState<TAddressRow[]>([])
+
+  const { addressBook, updateAddressBook } = useAddressBook()
+
+  const { data: totalBalances } = walletRPC.useTotalBalance()
+
+  const {
+    data: tAddresses = [],
+    isLoading: isTAddressesLoading,
+  } = walletRPC.useTAddressesWithBalance()
+
+  const {
+    data: zAddresses = [],
+    isLoading: isZAddressesLoading,
+  } = walletRPC.useZAddressesWithBalance()
+
+  const addresses = useMemo(() => [...zAddresses, ...tAddresses], [
+    tAddresses,
+    zAddresses,
+  ])
+
+  const [isLoadingAddresses, setIsLoadingAddresses] = useState(
+    isTAddressesLoading || isZAddressesLoading,
+  )
+
   const [walletOriginAddresses, setWalletOriginAddresses] = useState<
     TAddressRow[]
   >([])
-  const {
-    addressBook,
-    updateAddressBook,
-    isAddressBookLoaded,
-  } = useAddressBook()
-  /**
-   * Fetch total balances
-   */
-  const fetchTotalBalances = async () => {
-    // Total balance
-    const balances: TTotalBalance = await walletRPC.fetchTotalBalance()
-    setTotalBalances(balances)
-    setBalanceCards([
-      {
-        style: {
-          type: 'total_balance',
-          info: false,
-        },
-        psl: balances.total,
-        activeIcon: <TotalBalance />,
-        inactiveIcon: <TotalBalance variant='inactive' />,
-        info: 'Total Balance',
-      },
-      {
-        style: {
-          type: 'transparent',
-          info: false,
-        },
-        psl: balances.transparent,
-        activeIcon: <TransparencyBalance />,
-        inactiveIcon: <TransparencyBalance variant='inactive' />,
-        info: 'Transparent Information',
-      },
-      {
-        style: {
-          type: 'shielded',
-          info: false,
-        },
-        psl: balances.private,
-        activeIcon: <ShieldedBalance />,
-        inactiveIcon: <ShieldedBalance variant='inactive' />,
-        info: 'Shielded Information',
-      },
-    ])
-  }
+  const [walletAddresses, setWalletAddresses] = useState<TAddressRow[]>([])
 
-  /**
-   * Fetch wallet addresses
-   */
-  const fetchWalletAddresses = async () => {
-    // Get addresses with balance
-    const balanceAddresses = await walletRPC.fetchTandZAddressesWithBalance()
-    const addresses: TAddressRow[] = balanceAddresses.map(
-      (a: TAddressBalance) => {
-        const address = a.address.toString()
-        const type = isSapling(address) ? 'shielded' : 'transparent'
-        const [book] = addressBook.filter(b => b.address === address) || []
-        return {
-          id: address,
-          address: address,
-          amount: a.balance,
-          psl: info.pslPrice || 0,
-          type: type,
-          time: '',
-          qrCode: '',
-          viewKey: '',
-          privateKey: '',
-          addressNick: book ? book.label : '',
-        } as TAddressRow
-      },
-    )
-    setWalletAddresses(addresses)
-    setWalletOriginAddresses(addresses)
-  }
+  useEffect(() => {
+    if (!addresses) {
+      return
+    }
+
+    const addressRows = addresses.map(a => {
+      const address = a.address.toString()
+      const type = isSapling(address) ? 'shielded' : 'transparent'
+      const [book] = addressBook.filter(b => b.address === address) || []
+      return {
+        id: address,
+        address: address,
+        amount: a.balance,
+        psl: info.pslPrice || 0,
+        type: type,
+        time: '',
+        qrCode: '',
+        viewKey: '',
+        privateKey: '',
+        addressNick: book ? book.label : '',
+      } as TAddressRow
+    })
+
+    setWalletOriginAddresses(addressRows)
+    setWalletAddresses(addressRows)
+    setIsLoadingAddresses(false)
+  }, [addresses])
 
   const saveAddressLabel = (address: string, label: string): void => {
     // Update address nick
-    const newWalletAddress: TAddressRow[] = walletAddresses.map(a => {
-      return {
-        ...a,
-        addressNick: a.address === address ? label : a.addressNick || '',
-      }
-    })
+    const newWalletAddress: TAddressRow[] = walletAddresses.map(a => ({
+      ...a,
+      addressNick: a.address === address ? label : a.addressNick || '',
+    }))
     setWalletAddresses(newWalletAddress)
 
     updateAddressBook({ address, label })
   }
-
-  useEffect(() => {
-    const getTotalBalances = async () => {
-      await Promise.all([fetchTotalBalances(), fetchWalletAddresses()])
-    }
-    if (isAddressBookLoaded) {
-      getTotalBalances()
-    }
-  }, [isAddressBookLoaded])
 
   useEffect(() => {
     let tempSelectedAmount = 0
@@ -344,10 +267,6 @@ const WalletScreen = (): JSX.Element => {
     }
   }
 
-  const onTabToggle = (index: number) => {
-    setTabActive(index)
-  }
-
   return (
     <div>
       <Breadcrumbs
@@ -371,7 +290,7 @@ const WalletScreen = (): JSX.Element => {
               { label: 'Year', count: 12 },
             ]}
             activeIndex={tabActive}
-            onToggle={onTabToggle}
+            onToggle={setTabActive}
             itemActiveClassName='bg-gray-4a rounded-full text-white'
             countInactiveClassName='bg-warning-hover font-extrabold'
           />
@@ -386,83 +305,11 @@ const WalletScreen = (): JSX.Element => {
       </div>
 
       <div className='bg-gray-f8 pt-5 sm:px-10 md:px-60px'>
-        <div className='flex justify-between '>
-          {balanceCards.map((card, index) => (
-            <div
-              key={index}
-              onClick={() => {
-                setActive(index)
-              }}
-              className='relative cursor-pointer'
-            >
-              <div className='absolute top-15px right-15px'>
-                {card.style.info ? (
-                  <Tooltip
-                    classnames='pt-5px pl-9px pr-2.5 pb-1 text-xs'
-                    content={card.info}
-                    width={108}
-                    type='top'
-                  >
-                    <EliminationIcon size={20} className='text-gray-8e' />
-                  </Tooltip>
-                ) : null}
-              </div>
-              <div
-                className={cn(
-                  'font-extrabold flex sm:w-64 md:w-72 lg:w-335px xl:w-427px h-124px border-gray-e7 border rounded-lg',
-                  active === index && 'bg-white',
-                )}
-              >
-                <div className='pl-4 md:pl-4 lg:pl-4 xl:pl-39px flex items-center'>
-                  {active === index ? card.activeIcon : card.inactiveIcon}
-                </div>
-                <div className='pt-36px pl-2 md:pl-3 lg:pl-[43px]'>
-                  <div
-                    className={cn(
-                      'sm:text-xl md:text-2xl leading-6 pt-9',
-                      index === active ? 'text-gray-2d' : 'text-gray-71',
-                    )}
-                  >
-                    {info?.currencyName}{' '}
-                    <NumberFormat
-                      value={card.psl}
-                      displayType='text'
-                      thousandSeparator={true}
-                    />
-                  </div>
-                  {card.style.type === 'total_balance' ? (
-                    <div
-                      className={cn(
-                        'font-medium text-sm mt-2',
-                        active === index ? 'text-gray-71' : 'text-gray-a0',
-                      )}
-                    >
-                      Total balance
-                    </div>
-                  ) : card.style.type === 'transparent' ? (
-                    <div
-                      className={cn(
-                        'font-medium text-sm mt-2',
-                        active === index ? 'text-gray-71' : 'text-gray-a0',
-                      )}
-                    >
-                      Transparent
-                    </div>
-                  ) : (
-                    <div
-                      className={cn(
-                        'font-medium text-sm mt-2',
-                        active === index ? 'text-gray-71' : 'text-gray-a0',
-                      )}
-                    >
-                      Shielded
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
+        <BalanceCards
+          totalBalances={totalBalances}
+          activeTab={active}
+          setActiveTab={setActive}
+        />
         {totalBalances?.total && totalBalances?.total <= 0 && (
           <Alert
             variant='warning'
@@ -554,21 +401,31 @@ const WalletScreen = (): JSX.Element => {
         {walletAddresses.length == 0 && (
           <div className='min-h-[594px] bg-white rounded-lg mt-3.5 flex items-center min-h-594px justify-center pb-10'>
             <div>
-              <div className='font-normal text-gray-4a text-base text-center mb-3.5'>
-                You have no Addresses
-              </div>
-              <Button
-                variant='secondary'
-                className='w-247px px-0'
-                childrenClassName='w-full'
-              >
-                <div className='flex items-center ml-6 font-medium'>
-                  <ElectricityIcon size={11} className='text-blue-3f py-3' />
-                  <span className='text-sm ml-11px'>
-                    Generate a new PSL Address
-                  </span>
-                </div>
-              </Button>
+              {isLoadingAddresses && (
+                <Spinner className='w-8 h-8 text-blue-3f' />
+              )}
+              {!isLoadingAddresses && (
+                <>
+                  <div className='font-normal text-gray-4a text-base text-center mb-3.5'>
+                    You have no Addresses
+                  </div>
+                  <Button
+                    variant='secondary'
+                    className='w-247px px-0'
+                    childrenClassName='w-full'
+                  >
+                    <div className='flex items-center ml-6 font-medium'>
+                      <ElectricityIcon
+                        size={11}
+                        className='text-blue-3f py-3'
+                      />
+                      <span className='text-sm ml-11px'>
+                        Generate a new PSL Address
+                      </span>
+                    </div>
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         )}
@@ -606,16 +463,16 @@ const WalletScreen = (): JSX.Element => {
         handleClose={() => {
           setPaymentModalOpen(false)
         }}
-      ></PaymentModal>
+      />
       <TransactionHistoryModal
         isOpen={isTransactionHistoryModalOpen}
         handleClose={() => setTransactionHistoryModalOpen(false)}
-      ></TransactionHistoryModal>
+      />
       <ExportKeysModal
         isOpen={isExportKeysModalOpen}
         address={currentAddress}
         handleClose={() => setExportKeysModalOpen(false)}
-      ></ExportKeysModal>
+      />
       <ToastContainer
         className='flex flex-grow w-auto'
         hideProgressBar={true}

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -30,7 +30,7 @@ import './index.css'
 import 'core-js/stable'
 import 'regenerator-runtime/runtime'
 
-import React, { useEffect } from 'react'
+import React from 'react'
 import { render } from 'react-dom'
 import { hot } from 'react-hot-loader' // has to stay first
 import { Provider } from 'react-redux'
@@ -42,19 +42,19 @@ import Utilities from './features/utilities'
 import Root from './legacy/containers/Root'
 import store from './redux/store'
 import 'common/utils/initDayjs'
-import { sendEventToMain } from './features/app/rendererEvents'
-import { rendererSetup } from './features/app/rendererSetup'
+import { rendererSetup, RendererSetupHooks } from './features/app/rendererSetup'
+import { QueryClientProvider } from 'react-query'
+import { queryClient } from './common/utils/queryClient'
 
 rendererSetup()
 
 const App = () => {
-  useEffect(() => {
-    sendEventToMain('rendererStarted', null)
-  }, [])
-
   return (
     <Provider store={store}>
-      <Root />
+      <QueryClientProvider client={queryClient}>
+        <RendererSetupHooks />
+        <Root />
+      </QueryClientProvider>
       <ToastContainer hideProgressBar autoClose={5000} />
       <Utilities />
       <PastelModal />

--- a/src/types/rpc/wallet.ts
+++ b/src/types/rpc/wallet.ts
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react'
 import { TResponse } from './response'
 
 type TAddressBalance = {
@@ -11,17 +10,6 @@ type TAddressList = {
   address: string
   amount: number
   type: 'shielded' | 'transparent' | 'balance'
-}
-
-type TBalanceCard = {
-  style: {
-    type: string
-    info: boolean
-  }
-  psl: number
-  activeIcon: ReactNode
-  inactiveIcon: ReactNode
-  info: string
 }
 
 type TAddressBook = {
@@ -186,7 +174,6 @@ export type {
   TAddressRow,
   TAddressUtxo,
   TAddressList,
-  TBalanceCard,
   TAddressBook,
   TListUnspent,
   TAddressDelta,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5653,6 +5653,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -5800,6 +5805,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -7854,7 +7873,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4:
+detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -12128,6 +12147,11 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 js-string-escape@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -12889,6 +12913,14 @@ markdown-to-jsx@^7.1.0:
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz#f00bae66c0abe7dd2d274123f84cb6bd2a2c7c6a"
   integrity sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 matcher@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca"
@@ -13074,6 +13106,11 @@ micromatch@^4.0.2, micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -13348,6 +13385,13 @@ nano-css@^5.3.1:
     sourcemap-codec "^1.4.8"
     stacktrace-js "^2.0.2"
     stylis "^4.0.6"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoclone@^0.2.1:
   version "0.2.1"
@@ -13848,6 +13892,11 @@ objectorarray@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/objectorarray/-/objectorarray-1.0.5.tgz#2c05248bbefabd8f43ad13b41085951aac5e68a5"
   integrity sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -15989,6 +16038,15 @@ react-qr-reader@2.2.1:
     prop-types "^15.7.2"
     webrtc-adapter "^7.2.1"
 
+react-query@^3.19.6:
+  version "3.19.6"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.19.6.tgz#02bda891a3f0a0534934d9024350d655b268e82c"
+  integrity sha512-21WfvDgBXvPzJtG4gAxi0h6ipOUNPKZGR3vZJ17m/kHGbj9g6rPblc0lG4sY5oVLpM05LP+BdDt/IYfy0IIKmg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-range@1.8.8:
   version "1.8.8"
   resolved "https://registry.yarnpkg.com/react-range/-/react-range-1.8.8.tgz#2fe35596457f037357f5d53004ca8cfbfeaad427"
@@ -16602,6 +16660,11 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -16869,17 +16932,17 @@ rimraf@2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -19052,6 +19115,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unorm@^1.4.1:
   version "1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16038,7 +16038,7 @@ react-qr-reader@2.2.1:
     prop-types "^15.7.2"
     webrtc-adapter "^7.2.1"
 
-react-query@^3.19.6:
+react-query@3.19.6:
   version "3.19.6"
   resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.19.6.tgz#02bda891a3f0a0534934d9024350d655b268e82c"
   integrity sha512-21WfvDgBXvPzJtG4gAxi0h6ipOUNPKZGR3vZJ17m/kHGbj9g6rPblc0lG4sY5oVLpM05LP+BdDt/IYfy0IIKmg==


### PR DESCRIPTION
Added [react-query](https://react-query.tanstack.com/overview) library which helps to perform queries and it keeps a cache

Goal is to speed up loading of wallet screen. The screen depends on balances and addresses.

Balances and pastel price is fetched in interval by `PastelDBThread`, I modified the Thread to update cache of react-query for balances and to update redux store for pastel price when requests succeeded.

Addresses are fetched once app is started by `RendererSetupHooks` component.

On wallet page I used a Spinner component to indicate if data wasn't loaded yet in case if it will take to long to the Thread to load data, but normally I expect user to see balances and addresses immediately once page is opened

Removed the condition to load data in interval only when app is not packed.
